### PR TITLE
Add an options file where I'll be developing options independently 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.7
 # Install dependencies.
 ADD requirements.txt /requirements.txt
 ADD main.py /main.py
+ADD options.py /options.py
 RUN pip install -r requirements.txt
 
 CMD ["python", "/main.py"]

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
 
       Update the README file to include current statistics generated on ``full_year`` at ``full_time`` UTC.
 
-      Committed by <github-action[bot]> on behalf of <``username``>.
+      Committed by <github-actions[bot]> on behalf of <``username``>.
 
     required: false
 

--- a/main.py
+++ b/main.py
@@ -59,13 +59,9 @@ def formatWithIEC(sz: float):
 
 def gen_bar(percent: int, blocks: str):
     fmt_bar_left = blocks[-1] * int(percent / one_block_percent)
-    fmt_bar_mid = (
-        blocks[0]
-        if len(blocks) == 2
-        else blocks[
-            int((percent % one_block_percent) / (one_block_percent / (len(blocks) - 1)))
-        ]
-    )
+    fmt_bar_mid = (blocks[0] if len(blocks) == 2 else blocks[int(
+        (percent % one_block_percent) / (one_block_percent /
+                                         (len(blocks) - 1)))])
     return (fmt_bar_left + fmt_bar_mid).ljust(bar_width, blocks[0])
 
 
@@ -107,17 +103,15 @@ def get_stats():
     size_total = 0
 
     for repo in repo_list:
-        data = requests.get(
-            f"https://api.github.com/repos/{repo}/languages", headers=headers
-        ).json()
+        data = requests.get(f"https://api.github.com/repos/{repo}/languages",
+                            headers=headers).json()
         for lang in data:
             size = data[lang]
             langs[lang] += size
             size_total += size
 
     langs: typing.List[typing.Tuple[str, int]] = list(
-        sorted(langs.items(), key=lambda x: x[1], reverse=True)
-    )[:list_count]
+        sorted(langs.items(), key=lambda x: x[1], reverse=True))[:list_count]
 
     if show_total:
         if show_total_top:
@@ -151,11 +145,10 @@ def get_stats():
             fmt_bar = blocks[-1] * bar_width
 
         data_list.append(
-            line_format.replace("$NAME", fmt_name)
-            .replace("$SIZE", fmt_size)
-            .replace("$BAR", fmt_bar)
-            .replace("$PERCENT", fmt_percent)
-        )
+            line_format.replace("$NAME",
+                                fmt_name).replace("$SIZE", fmt_size).replace(
+                                    "$BAR",
+                                    fmt_bar).replace("$PERCENT", fmt_percent))
 
         if lang == "TOTAL":
             if show_total_separator and show_total_top:
@@ -183,9 +176,8 @@ if __name__ == "__main__":
 
     content = repo.get_readme()
     old_readme = str(base64.b64decode(content.content), "utf-8")
-    new_readme = re.sub(
-        listReg, f"{START_COMMENT}\n{stat_str}\n{END_COMMENT}", old_readme
-    )
+    new_readme = re.sub(listReg, f"{START_COMMENT}\n{stat_str}\n{END_COMMENT}",
+                        old_readme)
     repo.update_file(
         branch="master",
         path=content.path,

--- a/main.py
+++ b/main.py
@@ -59,9 +59,13 @@ def formatWithIEC(sz: float):
 
 def gen_bar(percent: int, blocks: str):
     fmt_bar_left = blocks[-1] * int(percent / one_block_percent)
-    fmt_bar_mid = (blocks[0] if len(blocks) == 2 else blocks[int(
-        (percent % one_block_percent) / (one_block_percent /
-                                         (len(blocks) - 1)))])
+    fmt_bar_mid = (
+        blocks[0]
+        if len(blocks) == 2
+        else blocks[
+            int((percent % one_block_percent) / (one_block_percent / (len(blocks) - 1)))
+        ]
+    )
     return (fmt_bar_left + fmt_bar_mid).ljust(bar_width, blocks[0])
 
 
@@ -103,15 +107,17 @@ def get_stats():
     size_total = 0
 
     for repo in repo_list:
-        data = requests.get(f"https://api.github.com/repos/{repo}/languages",
-                            headers=headers).json()
+        data = requests.get(
+            f"https://api.github.com/repos/{repo}/languages", headers=headers
+        ).json()
         for lang in data:
             size = data[lang]
             langs[lang] += size
             size_total += size
 
     langs: typing.List[typing.Tuple[str, int]] = list(
-        sorted(langs.items(), key=lambda x: x[1], reverse=True))[:list_count]
+        sorted(langs.items(), key=lambda x: x[1], reverse=True)
+    )[:list_count]
 
     if show_total:
         if show_total_top:
@@ -145,10 +151,11 @@ def get_stats():
             fmt_bar = blocks[-1] * bar_width
 
         data_list.append(
-            line_format.replace("$NAME",
-                                fmt_name).replace("$SIZE", fmt_size).replace(
-                                    "$BAR",
-                                    fmt_bar).replace("$PERCENT", fmt_percent))
+            line_format.replace("$NAME", fmt_name)
+            .replace("$SIZE", fmt_size)
+            .replace("$BAR", fmt_bar)
+            .replace("$PERCENT", fmt_percent)
+        )
 
         if lang == "TOTAL":
             if show_total_separator and show_total_top:
@@ -176,8 +183,9 @@ if __name__ == "__main__":
 
     content = repo.get_readme()
     old_readme = str(base64.b64decode(content.content), "utf-8")
-    new_readme = re.sub(listReg, f"{START_COMMENT}\n{stat_str}\n{END_COMMENT}",
-                        old_readme)
+    new_readme = re.sub(
+        listReg, f"{START_COMMENT}\n{stat_str}\n{END_COMMENT}", old_readme
+    )
     repo.update_file(
         branch="master",
         path=content.path,

--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ from github import Github
 
 from options import *
 
+c_message = generate_commit_message(os.getenv("INPUT_COMMIT_MESSAGE"))
+
 u_message = os.getenv("INPUT_COMMIT_MESSAGE")
 
 START_COMMENT = "<!--START_SECTION:top_language-->"
@@ -183,6 +185,6 @@ if __name__ == "__main__":
             branch="master",
             path=content.path,
             sha=content.sha,
-            message=u_message,
+            message=c_message,
             content=new_readme,
         )

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from github import Github
 
 exec('options.py')
 
-c_message = options.generate_commit_message(os.getenv("INPUT_COMMIT_MESSAGE"))
+c_message = generate_commit_message(os.getenv("INPUT_COMMIT_MESSAGE"))
 
 START_COMMENT = "<!--START_SECTION:top_language-->"
 END_COMMENT = "<!--END_SECTION:top_language-->"

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 
 import requests
 from github import Github
+from options import generate_commit_message
 
 exec('options.py')
 

--- a/main.py
+++ b/main.py
@@ -170,7 +170,7 @@ def get_stats():
 if __name__ == "__main__":
     g = Github(ghtoken_default)
 
-    repo = g.get_repo(f"{owner}/{owner}")
+    repo = g.get_repo(f"{owner}/ew")
 
     stat_str = get_stats()
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 #!/bin/python
 import base64
-import datetime
 import os
 import re
 import typing

--- a/main.py
+++ b/main.py
@@ -207,7 +207,7 @@ def get_stats():
 if __name__ == "__main__":
     g = Github(ghtoken_default)
 
-    repo = g.get_repo(f"{owner}/{owner}")
+    repo = g.get_repo(f"{owner}/ew")
 
     stat_str = get_stats()
 

--- a/main.py
+++ b/main.py
@@ -9,46 +9,9 @@ from collections import defaultdict
 import requests
 from github import Github
 
-# Include variables in the readme so that every commit can be "unique"
-# They can be expanded as your wish
+from options import *
 
-# Start the variable script
-input_string = os.getenv("INPUT_COMMIT_MESSAGE")
-now = datetime.datetime.now()
-current_date = now.strftime("%a %d %b %Y %H:%M:%S")
-
-full_year = now.strftime("%d %b %Y")
-full_time = now.strftime("%a %H:%M:%S")
-year = now.year
-month_no = now.month
-month_name = now.strftime("%B")
-day_no = now.day
-day_name = now.strftime("%A")
-minute = now.minute
-hour = now.hour
-my_username = os.getenv("INPUT_USERNAME")
-
-# Define a dictionary with placeholders and their corresponding values
-placeholders = {
-    "date": current_date,
-    "year": year,
-    "month_name": month_name,
-    "month_no": month_no,
-    "day_name": day_name,
-    "day_no": day_no,
-    "minute": minute,
-    "hour": hour,
-    "username": my_username,
-    "full_year": full_year,
-    "full_time": full_time,
-}
-
-# Iterate over the placeholders and replace them in the input string
-u_message = input_string
-for placeholder, value in placeholders.items():
-    u_message = u_message.replace(f"``{placeholder}``", str(value))
-
-# End the variable script
+u_message = os.getenv("INPUT_COMMIT_MESSAGE")
 
 START_COMMENT = "<!--START_SECTION:top_language-->"
 END_COMMENT = "<!--END_SECTION:top_language-->"

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import requests
 from github import Github
 
-import options
+exec('options.py')
 
 c_message = options.generate_commit_message(os.getenv("INPUT_COMMIT_MESSAGE"))
 

--- a/main.py
+++ b/main.py
@@ -9,11 +9,9 @@ from collections import defaultdict
 import requests
 from github import Github
 
-from options import *
+import options
 
-c_message = generate_commit_message(os.getenv("INPUT_COMMIT_MESSAGE"))
-
-u_message = os.getenv("INPUT_COMMIT_MESSAGE")
+c_message = options.generate_commit_message(os.getenv("INPUT_COMMIT_MESSAGE"))
 
 START_COMMENT = "<!--START_SECTION:top_language-->"
 END_COMMENT = "<!--END_SECTION:top_language-->"

--- a/main.py
+++ b/main.py
@@ -9,46 +9,9 @@ from collections import defaultdict
 import requests
 from github import Github
 
-# Include variables in the readme so that every commit can be "unique"
-# They can be expanded as your wish
+import options
 
-# Start the variable script
-input_string = os.getenv("INPUT_COMMIT_MESSAGE")
-now = datetime.datetime.now()
-current_date = now.strftime("%a %d %b %Y %H:%M:%S")
-
-full_year = now.strftime("%d %b %Y")
-full_time = now.strftime("%a %H:%M:%S")
-year = now.year
-month_no = now.month
-month_name = now.strftime("%B")
-day_no = now.day
-day_name = now.strftime("%A")
-minute = now.minute
-hour = now.hour
-my_username = os.getenv("INPUT_USERNAME")
-
-# Define a dictionary with placeholders and their corresponding values
-placeholders = {
-    "date": current_date,
-    "year": year,
-    "month_name": month_name,
-    "month_no": month_no,
-    "day_name": day_name,
-    "day_no": day_no,
-    "minute": minute,
-    "hour": hour,
-    "username": my_username,
-    "full_year": full_year,
-    "full_time": full_time,
-}
-
-# Iterate over the placeholders and replace them in the input string
-u_message = input_string
-for placeholder, value in placeholders.items():
-    u_message = u_message.replace(f"``{placeholder}``", str(value))
-
-# End the variable script
+c_message = options.generate_commit_message(os.getenv("INPUT_COMMIT_MESSAGE"))
 
 START_COMMENT = "<!--START_SECTION:top_language-->"
 END_COMMENT = "<!--END_SECTION:top_language-->"
@@ -219,6 +182,6 @@ if __name__ == "__main__":
         branch="master",
         path=content.path,
         sha=content.sha,
-        message=u_message,
+        message=c_message,
         content=new_readme,
     )

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 #!/bin/python
 import base64
+import datetime
 import os
 import re
 import typing
@@ -7,11 +8,47 @@ from collections import defaultdict
 
 import requests
 from github import Github
-from options import generate_commit_message
 
-exec('options.py')
+# Include variables in the readme so that every commit can be "unique"
+# They can be expanded as your wish
 
-c_message = generate_commit_message(os.getenv("INPUT_COMMIT_MESSAGE"))
+# Start the variable script
+input_string = os.getenv("INPUT_COMMIT_MESSAGE")
+now = datetime.datetime.now()
+current_date = now.strftime("%a %d %b %Y %H:%M:%S")
+
+full_year = now.strftime("%d %b %Y")
+full_time = now.strftime("%a %H:%M:%S")
+year = now.year
+month_no = now.month
+month_name = now.strftime("%B")
+day_no = now.day
+day_name = now.strftime("%A")
+minute = now.minute
+hour = now.hour
+my_username = os.getenv("INPUT_USERNAME")
+
+# Define a dictionary with placeholders and their corresponding values
+placeholders = {
+    "date": current_date,
+    "year": year,
+    "month_name": month_name,
+    "month_no": month_no,
+    "day_name": day_name,
+    "day_no": day_no,
+    "minute": minute,
+    "hour": hour,
+    "username": my_username,
+    "full_year": full_year,
+    "full_time": full_time,
+}
+
+# Iterate over the placeholders and replace them in the input string
+u_message = input_string
+for placeholder, value in placeholders.items():
+    u_message = u_message.replace(f"``{placeholder}``", str(value))
+
+# End the variable script
 
 START_COMMENT = "<!--START_SECTION:top_language-->"
 END_COMMENT = "<!--END_SECTION:top_language-->"
@@ -170,7 +207,7 @@ def get_stats():
 if __name__ == "__main__":
     g = Github(ghtoken_default)
 
-    repo = g.get_repo(f"{owner}/ew")
+    repo = g.get_repo(f"{owner}/{owner}")
 
     stat_str = get_stats()
 
@@ -178,11 +215,10 @@ if __name__ == "__main__":
     old_readme = str(base64.b64decode(content.content), "utf-8")
     new_readme = re.sub(listReg, f"{START_COMMENT}\n{stat_str}\n{END_COMMENT}",
                         old_readme)
-    if new_readme != old_readme:
-        repo.update_file(
-            branch="master",
-            path=content.path,
-            sha=content.sha,
-            message=c_message,
-            content=new_readme,
-        )
+    repo.update_file(
+        branch="master",
+        path=content.path,
+        sha=content.sha,
+        message=u_message,
+        content=new_readme,
+    )

--- a/main.py
+++ b/main.py
@@ -170,7 +170,7 @@ def get_stats():
 if __name__ == "__main__":
     g = Github(ghtoken_default)
 
-    repo = g.get_repo(f"{owner}/ew")
+    repo = g.get_repo(f"{owner}/{owner}")
 
     stat_str = get_stats()
 

--- a/options.py
+++ b/options.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 
+
 def generate_commit_message(input_string):
     now = datetime.datetime.now()
     current_date = now.strftime("%a %d %b %Y %H:%M:%S")

--- a/options.py
+++ b/options.py
@@ -1,48 +1,37 @@
-#!/bin/python
-
 import datetime
 import os
 
-# Include variables in the readme so that every commit can be "unique"
-# They can be expanded as your wish
+def generate_commit_message(input_string):
+    now = datetime.datetime.now()
+    current_date = now.strftime("%a %d %b %Y %H:%M:%S")
 
-# Start the variable script
-input_string = os.getenv("INPUT_COMMIT_MESSAGE")
-now = datetime.datetime.now()
-current_date = now.strftime("%a %d %b %Y %H:%M:%S")
+    full_year = now.strftime("%d %b %Y")
+    full_time = now.strftime("%a %H:%M:%S")
+    year = now.year
+    month_no = now.month
+    month_name = now.strftime("%B")
+    day_no = now.day
+    day_name = now.strftime("%A")
+    minute = now.minute
+    hour = now.hour
+    my_username = os.getenv("INPUT_USERNAME")
 
-full_year = now.strftime("%d %b %Y")
-full_time = now.strftime("%a %H:%M:%S")
-year = now.year
-month_no = now.month
-month_name = now.strftime("%B")
-day_no = now.day
-day_name = now.strftime("%A")
-minute = now.minute
-hour = now.hour
-my_username = os.getenv("INPUT_USERNAME")
+    placeholders = {
+        "date": current_date,
+        "year": year,
+        "month_name": month_name,
+        "month_no": month_no,
+        "day_name": day_name,
+        "day_no": day_no,
+        "minute": minute,
+        "hour": hour,
+        "username": my_username,
+        "full_year": full_year,
+        "full_time": full_time,
+    }
 
-# Define a dictionary with placeholders and their corresponding values
-placeholders = {
-    "date": current_date,
-    "year": year,
-    "month_name": month_name,
-    "month_no": month_no,
-    "day_name": day_name,
-    "day_no": day_no,
-    "minute": minute,
-    "hour": hour,
-    "username": my_username,
-    "full_year": full_year,
-    "full_time": full_time,
-}
+    u_message = input_string
+    for placeholder, value in placeholders.items():
+        u_message = u_message.replace(f"``{placeholder}``", str(value))
 
-# Iterate over the placeholders and replace them in the input string
-u_message = input_string
-for placeholder, value in placeholders.items():
-    u_message = u_message.replace(f"``{placeholder}``", str(value))
-    
-
-print(u_message)
-
-# End the variable script
+    return u_message

--- a/options.py
+++ b/options.py
@@ -1,3 +1,5 @@
+#!/bin/python
+
 import datetime
 import os
 

--- a/options.py
+++ b/options.py
@@ -1,0 +1,48 @@
+#!/bin/python
+
+import datetime
+import os
+
+# Include variables in the readme so that every commit can be "unique"
+# They can be expanded as your wish
+
+# Start the variable script
+input_string = os.getenv("INPUT_COMMIT_MESSAGE")
+now = datetime.datetime.now()
+current_date = now.strftime("%a %d %b %Y %H:%M:%S")
+
+full_year = now.strftime("%d %b %Y")
+full_time = now.strftime("%a %H:%M:%S")
+year = now.year
+month_no = now.month
+month_name = now.strftime("%B")
+day_no = now.day
+day_name = now.strftime("%A")
+minute = now.minute
+hour = now.hour
+my_username = os.getenv("INPUT_USERNAME")
+
+# Define a dictionary with placeholders and their corresponding values
+placeholders = {
+    "date": current_date,
+    "year": year,
+    "month_name": month_name,
+    "month_no": month_no,
+    "day_name": day_name,
+    "day_no": day_no,
+    "minute": minute,
+    "hour": hour,
+    "username": my_username,
+    "full_year": full_year,
+    "full_time": full_time,
+}
+
+# Iterate over the placeholders and replace them in the input string
+u_message = input_string
+for placeholder, value in placeholders.items():
+    u_message = u_message.replace(f"``{placeholder}``", str(value))
+    
+
+print(u_message)
+
+# End the variable script

--- a/options.py
+++ b/options.py
@@ -1,5 +1,3 @@
-#!/bin/python
-
 import datetime
 import os
 

--- a/options.py
+++ b/options.py
@@ -5,8 +5,8 @@ def generate_commit_message(input_string):
     now = datetime.datetime.now()
     current_date = now.strftime("%a %d %b %Y %H:%M:%S")
 
-    full_year = now.strftime("%d %b %Y")
-    full_time = now.strftime("%a %H:%M:%S")
+    full_year = now.strftime("%a %d %b %Y")
+    full_time = now.strftime("%H:%M:%S")
     year = now.year
     month_no = now.month
     month_name = now.strftime("%B")


### PR DESCRIPTION
- chore: Seperate the workload into different files
- change repo name
- create a module
- execute it
- import it
- import it again
- execute the file
- remove options
- add options
- supress options
- update path
- add options to dockerfile
- add options to dockerfile
- return to `owner\@owner`
- update the wordings
