### PR TITLE
Revert "Bump cryptography from 41.0.3 to 41.0.4 (#51)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2023.7.22
 cffi==1.16.0
 chardet==5.2.0
 charset-normalizer==3.2.0
-cryptography==41.0.4
+cryptography==41.0.3
 deprecated==1.2.14
 idna==3.4
 pycparser==2.21


### PR DESCRIPTION
This reverts commit 76c3e0e5eae08ab88b2bd59ea14cc421fce86a37.

Signed-off-by: Gekko Wrld <108436933+gekkowrld@users.noreply.github.com>
